### PR TITLE
Use THEME_STATIC_DIR for asset URL's

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,13 +3,13 @@
 <head>
   <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic' rel='stylesheet' type='text/css'>
   {% if USE_LESS %}
-  <link rel="stylesheet/less" type="text/css" href="{{ SITEURL }}/theme/css/style.less">
+  <link rel="stylesheet/less" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/style.less">
   <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js" type="text/javascript"></script>
   {% else %}
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/style.min.css">
+  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/style.min.css">
   {% endif %}
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygments.min.css">
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/font-awesome.min.css">
+  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/pygments.min.css">
+  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/font-awesome.min.css">
   {% if FEED_ALL_ATOM %}
   <link href="{{ FEED_DOMAIN }}/{{ FEED_ALL_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom">
   {% endif %}
@@ -39,7 +39,7 @@
         {% if SITELOGO %}
         <img src="{{ SITELOGO }}" alt="{{ SITETITLE }}" title="{{ SITETITLE }}">
         {% else %}
-        <img src="{{ SITEURL }}/theme/img/profile.png" alt="{{ SITETITLE }}" title="{{ SITETITLE }}">
+        <img src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/img/profile.png" alt="{{ SITETITLE }}" title="{{ SITETITLE }}">
         {% endif %}
       </a>
       <h1><a href="{{ SITEURL }}">{{ SITETITLE }}</a></h1>

--- a/templates/partial/jsonld_article.html
+++ b/templates/partial/jsonld_article.html
@@ -1,7 +1,7 @@
 {% if SITELOGO %}
   {% set default_cover = SITELOGO %}
 {% else %}
-  {% set default_cover = '{{ SITEURL }}/theme/img/profile.png' %}
+  {% set default_cover = '{{ SITEURL }}/{{ THEME_STATIC_DIR }}/img/profile.png' %}
 {% endif %}
 <script type="application/ld+json">
 {


### PR DESCRIPTION
Pelican allows to use `THEME_STATIC_DIR` configuration variable to control where the theme files are placed in the generated page output. The theme itself, however, must use it in its templates.

Currently, Flex hardcodes it to `theme`, which is the default value. This change makes it use the configuration option correctly instead.