### PR TITLE
Add support for Piwik

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A minimalist [Pelican](http://blog.getpelican.com/) theme.
 - Disqus
 - Google Analytics
 - Google Tag Manager
+- Piwik
 - StatusCake
 
 ## Need Docs?

--- a/templates/base.html
+++ b/templates/base.html
@@ -98,5 +98,23 @@
   <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid={{ ADD_THIS_ID }}" async="async"></script>
   {% endif %}
   {% block additional_js %}{% endblock %}
+
+  {% if PIWIK_URL and PIWIK_SITE_ID %}
+  <!-- Piwik -->
+  <script type="text/javascript">
+    var _paq = _paq || [];
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="//{{ PIWIK_URL }}/";
+      _paq.push(['setTrackerUrl', u+'piwik.php']);
+      _paq.push(['setSiteId', {{ PIWIK_SITE_ID }}]);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <noscript><p><img src="//bnjbvr.alwaysdata.net/piwik/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
+  <!-- End Piwik Code -->
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
Hi! Thank you for this awesome pelican theme. Please find here a PR that allows one to support Piwik integration (it's like Google Analytics but self-hosted), if the PIWIK_SITE_ID and PIWIK_URL are set in the configuration.