### PR TITLE
Fixed a bug with placement of Newer Posts button

### DIFF
--- a/templates/partial/pagination.html
+++ b/templates/partial/pagination.html
@@ -8,7 +8,7 @@
   {% if articles_page.has_previous() %}
     <a class="btn float-right" href="{{ SITEURL }}/{{ articles_previous_page.url }}">
       Newer Posts <i class="fa fa-angle-right"></i>
-    </a>
+    </a><div style='clear:both'></div>
   {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
Fixes #21 by adding a `div` container after closing `a` tag for correct placement of the button.