### PR TITLE
Strip HTML tags from title

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -7,7 +7,7 @@
 {% include "partial/og_article.html" %}
 {% endblock %}
 
-{% block title %} &ndash; {{ article.title }}{% endblock %}
+{% block title %} &ndash; {{ article.title|striptags }}{% endblock %}
 
 {% block content %}
 <article>

--- a/templates/partial/jsonld_article.html
+++ b/templates/partial/jsonld_article.html
@@ -7,8 +7,8 @@
 {
   "@context": "http://schema.org",
   "@type": "BlogPosting",
-  "name": "{{ article.title }}",
-  "headline": "{{ article.title }}",
+  "name": "{{ article.title|striptags }}",
+  "headline": "{{ article.title|striptags }}",
   "datePublished": "{{ article.date }}",
   "dateModified": "{{ article.modified }}",
   "author": {

--- a/templates/partial/og_article.html
+++ b/templates/partial/og_article.html
@@ -4,7 +4,7 @@
   {% set default_locale = 'en_US' %}
 {% endif %}
 <meta property="og:site_name" content="{{ SITENAME }}"/>
-<meta property="og:title" content="{{ article.title }}"/>
+<meta property="og:title" content="{{ article.title|striptags }}"/>
 <meta property="og:description" content="{{ article.summary|striptags }}"/>
 <meta property="og:locale" content="{{ article.metadata.get('og_locale', default_locale) }}"/>
 <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>


### PR DESCRIPTION
Remove HTML tags from the page title. 
This happens for example if Typogrify is activated and the title contains something like PHP. Looks ugly and especially breaks the design in mobile mode.