### PR TITLE
Update archives template to display the date once all articles on the date.

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -10,7 +10,7 @@
     <dl>
       {% set previous_date = False %}
       {% for article in dates %}
-        {% if article.locale_date != previous_date: %}
+        {% if article.locale_date != previous_date %}
           {% set previous_date = article.locale_date %}
       <dt>{{ article.locale_date }}</dt>
         {% endif %}

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -8,8 +8,12 @@
   </header>
   <div>
     <dl>
+      {% set previous_date = False %}
       {% for article in dates %}
+        {% if article.locale_date != previous_date: %}
+          {% set previous_date = article.locale_date %}
       <dt>{{ article.locale_date }}</dt>
+        {% endif %}
       <dd><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></dd>
       {% endfor %}
     </dl>


### PR DESCRIPTION
The old method printed the date for every article even if they had the
same publish date. This update prints the date once for all articles
published on that date.

Old
```
Sun 17 May 2015
  Article One
Sun 17 May 2015
  Article Two
Sun 17 May 2015
  Article Three
```

New
```
Sun 17 May 2015
  Article One
  Article Two
  Article Three
```