### PR TITLE
wrap aside elements in order to minimise empty space if they are unde…

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -66,7 +66,8 @@
         {% endif %}
       </a>
       <h1><a href="{{ SITEURL }}">{{ SITETITLE }}</a></h1>
-      <p>{{ SITESUBTITLE }}</p>
+      {% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}
+      {% if pages %}
       <nav>
         <ul class="list">
           {% for page in pages|sort(attribute='title') %}
@@ -77,6 +78,7 @@
           {% endfor %}
         </ul>
       </nav>
+      {% endif %}
       <ul class="social">
         {% for name, link in SOCIAL %}
         <li><a class="sc-{{ name }}" href="{{ link }}" target="_blank"><i class="fa fa-{{ name }}"></i></a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
       </a>
       <h1><a href="{{ SITEURL }}">{{ SITETITLE }}</a></h1>
       {% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}
-      {% if pages %}
+      {% if pages or LINKS %}
       <nav>
         <ul class="list">
           {% for page in pages|sort(attribute='title') %}


### PR DESCRIPTION
If you don't define SITESUBTITLE or have any pages there is a lot of empty space between the title and the social links. This patch wraps the related elements in if statements in order to remove the excess whitespace :)