### PR TITLE
Use webassets if enabled, improves PR #20

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic' rel='stylesheet' type='text/css'>
 
+  {% set PYGMENTS_CSS %}pygments/{{ PYGMENTS_STYLE|default('github') }}.min.css{% endset %}
   {% if USE_LESS %}
     <link rel="stylesheet/less" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/stylesheet/style.less">
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js" type="text/javascript"></script>
@@ -10,11 +11,15 @@
     <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/stylesheet/style.min.css">
   {% endif %}
 
-  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/pygments/{{ PYGMENTS_STYLE|default('github') }}.min.css">
+  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/{{ PYGMENTS_CSS }}">
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/font-awesome/css/font-awesome.min.css">
 
   {% if CUSTOM_CSS %}
-    <link href="{{ SITEURL }}/{{ CUSTOM_CSS }}" rel="stylesheet">
+    {% if 'assets' in PLUGINS %}
+      {% include 'partial/assets.html' %}
+    {% else %}
+      <link href="{{ SITEURL }}/{{ CUSTOM_CSS }}" rel="stylesheet">
+    {% endif %}
   {% endif %}
 
   {% if FEED_ALL_ATOM %}

--- a/templates/partial/assets.html
+++ b/templates/partial/assets.html
@@ -1,0 +1,3 @@
+{% assets CUSTOM_CSS, filters="cssmin", output="custom.min.css" %}
+  <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ ASSET_URL }}">
+{% endassets %}


### PR DESCRIPTION
Sorry for opening another PR for the same issue but I can't push to the previous one. 
This version uses a conditional include if we want to use webassets, otherwise Jinja fails b/c it can't recognize the assets tag. Not ideal but this is the only way to get it working.  The rest is shuffling the HTML around. Let me know what you think.

