### PR TITLE
Reworked to newstyle gettext and named vars

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,1 +1,2 @@
 [jinja2: templates/**.html]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %} &ndash; {% trans %}Archives{% endtrans %}{% endblock %}
+{% block title %} &ndash; {{ _('Archives') }}{% endblock %}
 
 {% block content %}
 <article>
   <header>
-    <h1>{% trans %}Archives{% endtrans %}</h1>
+    <h1>{{ _('Archives') }}</h1>
   </header>
   <div>
     <dl>

--- a/templates/article.html
+++ b/templates/article.html
@@ -13,7 +13,13 @@
 <article>
   <header>
     <h1 id="{{ article.slug }}">{{ article.title }}</h1>
-    <p>{% trans %}Posted on{% endtrans %} {{ article.locale_date }} {% trans %}in{% endtrans %} <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a></p>
+    <p>
+      {% autoescape false %}
+      {{ _('Posted on %(when)s in %(category)s',
+        when=article.locale_date,
+        category='<a href="%s/%s">%s</a>' % (SITEURL, article.category.url, article.category)) }}
+      {% endautoescape %}
+    </p>
   </header>
   <div>
     {{ article.content }}
@@ -29,14 +35,14 @@
   </div>
   {% if ADD_THIS_ID %}
   <div class="center social-share">
-    <p>{% trans %}Like this article? Share it with your friends!{% endtrans %}</p>
+    <p>{{ _('Like this article? Share it with your friends!') }}</p>
     <div class="addthis_native_toolbox"></div>
     <div class="addthis_sharing_toolbox"></div>
   </div>
   {% endif %}
   {% if article.related_posts %}
   <div class="related-posts">
-    <h4>{% trans %}Related posts{% endtrans %}:</h4>
+    <h4>{{ _('Related posts') }}:</h4>
     <ul>
     {% for related_post in article.related_posts %}
       <li><a href="{{ SITEURL }}/{{ related_post.url }}">{{ related_post.title }}</a></li>

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,3 +1,3 @@
 {% extends "index.html" %}
-{% block title %} &ndash; {% trans %}Posts by{% endtrans %}: {{ author }}{% endblock %}
+{% block title %} &ndash; {{ _('Posts by %(name)s', name=author) }}:{% endblock %}
 {% set summarise = True %}

--- a/templates/authors.html
+++ b/templates/authors.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %} &ndash; {% trans %}Authors{% endtrans %}{% endblock %}
+{% block title %} &ndash; {{ _('Authors') }}{% endblock %}
 
 {% block content %}
 <article>
   <header>
-    <h1>{% trans %}Authors{% endtrans %}</h1>
+    <h1>{{ _('Authors') }}</h1>
   </header>
   <div>
     <ul class="list">

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %} &ndash; {% trans %}Categories{% endtrans %}{% endblock %}
+{% block title %} &ndash; {{ _('Categories') }}{% endblock %}
 
 {% block content %}
 <article>
   <header>
-    <h1>{% trans %}Categories{% endtrans %}</h1>
+    <h1>{{ _('Categories') }}</h1>
   </header>
   <div>
     <ul class="list">

--- a/templates/category.html
+++ b/templates/category.html
@@ -1,3 +1,3 @@
 {% extends "index.html" %}
-{% block title %} &ndash; {% trans %}Category{% endtrans %}: {{ category }}{% endblock %}
+{% block title %} &ndash; {{ _('Category: %(name)s', name=category) }}{% endblock %}
 {% set summarise = True %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,22 +6,26 @@
   <header>
     <h2><a href="{{ SITEURL }}/{{ article.url }}#{{ article.slug }}">{{ article.title }}</a></h2>
     <p>
-      {% trans %}Posted on{% endtrans %} {{ article.locale_date }} {% trans %}in{% endtrans %} <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>
+      {% autoescape false %}
+      {{ _('Posted on %(when)s in %(category)s',
+        when=article.locale_date,
+        category='<a href="%s/%s">%s</a>' % (SITEURL, article.category.url, article.category)) }}
+      {% endautoescape %}
       {% if article.tags %}
-      &#8226; {% trans %}Tagged with{% endtrans %}
+      &#8226; {{ ngettext('Tag', 'Tags', article.tags|count) }}:
       {% for tag in article.tags %}
       <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% if not loop.last %},{% endif %}
       {% endfor %}
       {% endif %}
       {% if DISQUS_SITENAME %}
-      &#8226; <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">{% trans %}Leave a comment{% endtrans %}</a>
+      &#8226; <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread">{{ _('Leave a comment') }}</a>
       {% endif %}
     </p>
   </header>
   <div>
     {% if summarise or article.metadata['summary'] or SUMMARY_MAX_LENGTH %}
       {{ article.summary }}
-      <a class="btn" href="{{ SITEURL }}/{{ article.url }}#{{ article.slug }}">{% trans %}Continue reading{% endtrans %}</a>
+      <a class="btn" href="{{ SITEURL }}/{{ article.url }}#{{ article.slug }}">{{ _('Continue reading') }}</a>
     {% else %}
       {{ article.content }}
     {% endif %}

--- a/templates/partial/disqus.html
+++ b/templates/partial/disqus.html
@@ -8,5 +8,11 @@
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>
-<noscript>{% trans %}Please enable JavaScript to view the{% endtrans %} <a href="https://disqus.com/?ref_noscript" rel="nofollow">{% trans %}comments powered by Disqus{% endtrans %}.</a></noscript>
+<noscript>
+  {% autoescape false %}
+    {{ _('Please enable JavaScript to view the %(link)scomments powered by Disqus%(endlink)s',
+    link='<a href="https://disqus.com/?ref_noscript" rel="nofollow">',
+    endlink='</a>') }}
+  {% endautoescape %}
+</noscript>
 {% endif %}

--- a/templates/partial/flex.html
+++ b/templates/partial/flex.html
@@ -1,1 +1,6 @@
-<p>{% trans %}Built using{% endtrans %} <a href="http://getpelican.com" target="_blank">Pelican</a> - <a href="https://github.com/alexandrevicenzi/flex" target="_blank">Flex</a> {% trans %}theme by{% endtrans %} <a href="http://alexandrevicenzi.com" target="_blank">Alexandre Vicenzi</a></p>
+{% autoescape false %}
+<p>{{ _('Build using %(pelican)s - %(flex)s theme by %(alexandrevicenzi)s',
+  pelican='<a href="http://getpelican.com" target="_blank">Pelican</a>',
+  flex='<a href="https://github.com/alexandrevicenzi/flex" target="_blank">Flex</a>',
+  alexandrevicenzi='<a href="http://alexandrevicenzi.com" target="_blank">Alexandre Vicenzi</a>') }}</p>
+{% endautoescape %}

--- a/templates/partial/pagination.html
+++ b/templates/partial/pagination.html
@@ -2,12 +2,12 @@
   <div class="pagination">
   {% if articles_page.has_next() %}
     <a class="btn" href="{{ SITEURL }}/{{ articles_next_page.url }}">
-      <i class="fa fa-angle-left"></i> {% trans %}Older Posts{% endtrans %}
+      <i class="fa fa-angle-left"></i> {{ _('Older Posts') }}
     </a>
   {% endif %}
   {% if articles_page.has_previous() %}
     <a class="btn float-right" href="{{ SITEURL }}/{{ articles_previous_page.url }}">
-      {% trans %}Newer Posts{% endtrans %} <i class="fa fa-angle-right"></i>
+      {{ _('Newer Posts') }} <i class="fa fa-angle-right"></i>
     </a>
   {% endif %}
   </div>

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -1,3 +1,3 @@
 {% extends "index.html" %}
-{% block title %} &ndash; {% trans %}Tag{% endtrans %}: {{ tag }}{% endblock %}
+{% block title %} &ndash; {{ _('Tag: %(name)s', name=tag) }}{% endblock %}
 {% set summarise = True %}

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block title %} &ndash; {% trans %}Tags{% endtrans %}{% endblock %}
+{% block title %} &ndash; {{ _('Tags') }}{% endblock %}
 
 {% block content %}
 <article>
   <header>
-    <h1>{% trans %}Tags{% endtrans %}</h1>
+    <h1>{{ _('Tags') }}</h1>
   </header>
   <div>
     <ul class="list">

--- a/tests/pelicanconf.py
+++ b/tests/pelicanconf.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 PLUGIN_PATHS = ['../plugins']
 PLUGINS = ['i18n_subsites']
 
-JINJA_EXTENSIONS = ['jinja2.ext.i18n']
+JINJA_EXTENSIONS = ['jinja2.ext.i18n', 'jinja2.ext.autoescape', 'jinja2.ext.with_']
 
 AUTHOR = u'Test'
 SITEURL = u'http://localhost:8000'

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1,13 +1,14 @@
 # German translations for pelican Flex theme by Alexandre Vicenzi.
 # Copyright (C) 2016 Marcel Huth
-# This file is distributed under the same license as the Flex theme by Alexandre Vicenzi project.
+# This file is distributed under the same license as the Flex theme by
+# Alexandre Vicenzi project.
 # Marcel Huth <marcelhuth@users.noreply.github.com>, 2016.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 1.0\n"
+"Project-Id-Version:  1.1\n"
 "Report-Msgid-Bugs-To: marcelhuth@users.noreply.github.com\n"
-"POT-Creation-Date: 2016-07-30 13:55+0200\n"
+"POT-Creation-Date: 2016-08-10 18:20+0200\n"
 "PO-Revision-Date: 2016-07-30 13:56+0200\n"
 "Last-Translator: Marcel Huth <marcelhuth@users.noreply.github.com>\n"
 "Language: de\n"
@@ -22,25 +23,23 @@ msgstr ""
 msgid "Archives"
 msgstr "Archive"
 
-#: templates/article.html:16 templates/index.html:9
-msgid "Posted on"
-msgstr "Online seit"
+#: templates/article.html:18 templates/index.html:10
+#, python-format
+msgid "Posted on %(when)s in %(category)s"
+msgstr "Online seit %(when)s in %(category)s"
 
-#: templates/article.html:16 templates/index.html:9
-msgid "in"
-msgstr "in"
-
-#: templates/article.html:32
+#: templates/article.html:38
 msgid "Like this article? Share it with your friends!"
 msgstr "Gef&auml;llt dir der Artikel? Dann teile ihn mit Freunden!"
 
-#: templates/article.html:39
+#: templates/article.html:45
 msgid "Related posts"
 msgstr "&Auml;hnliche Artikel"
 
 #: templates/author.html:2
-msgid "Posts by"
-msgstr "Geschrieben von"
+#, python-format
+msgid "Posts by %(name)s"
+msgstr "Artikel von %(name)s"
 
 #: templates/authors.html:2 templates/authors.html:7
 msgid "Authors"
@@ -51,44 +50,46 @@ msgid "Categories"
 msgstr "Kategorien"
 
 #: templates/category.html:2
-msgid "Category"
-msgstr "Kategorie"
+#, python-format
+msgid "Category: %(name)s"
+msgstr "Kategorie: %(name)s"
 
-#: templates/index.html:11
-msgid "Tagged with"
-msgstr "Stichw&ouml;rter"
+#: templates/index.html:15
+msgid "Tag"
+msgid_plural "Tags"
+msgstr[0] "Stichwort"
+msgstr[1] "Stichw&ouml;rter"
 
-#: templates/index.html:17
+#: templates/index.html:21
 msgid "Leave a comment"
-msgstr "Schreib einen Kommentar"
+msgstr "Hinterlasse ein Kommentar"
 
-#: templates/index.html:24
+#: templates/index.html:28
 msgid "Continue reading"
 msgstr "Weiterlesen"
 
 #: templates/tag.html:2
-msgid "Tag"
-msgstr "Stichw&ouml;rt"
+#, python-format
+msgid "Tag: %(name)s"
+msgstr "Stichwort: %(name)s"
 
 #: templates/tags.html:2 templates/tags.html:7
 msgid "Tags"
 msgstr "Stichw&ouml;rter"
 
-#: templates/partial/disqus.html:11
-msgid "Please enable JavaScript to view the"
-msgstr "Bitte aktiviere JavaScript um die"
+#: templates/partial/disqus.html:13
+#, python-format
+msgid ""
+"Please enable JavaScript to view the %(link)scomments powered by "
+"Disqus%(endlink)s"
+msgstr ""
+"Bitte JavaScript aktivieren um die %(link)sKommentare von "
+"Disqus%(endlink)s zu lesen"
 
-#: templates/partial/disqus.html:11
-msgid "comments powered by Disqus"
-msgstr "Kommentare von Disqus anzuzeigen"
-
-#: templates/partial/flex.html:1
-msgid "Built using"
-msgstr "Erstellt mit"
-
-#: templates/partial/flex.html:1
-msgid "theme by"
-msgstr "Theme von"
+#: templates/partial/flex.html:2
+#, python-format
+msgid "Build using %(pelican)s - %(flex)s theme by %(alexandrevicenzi)s"
+msgstr "Erstellt mit %(pelican)s - %(flex)s Design von %(alexandrevicenzi)s"
 
 #: templates/partial/pagination.html:5
 msgid "Older Posts"


### PR DESCRIPTION
The translation of the theme is now done with newstyle gettext and named variables that syntax of sentences wouldn't be broken when translation to several languages. This fixes #43 

With newstyle gettext you have to add Jinja2 filters in your `pelicanconf.py`. Should look like this:
```python
JINJA_EXTENSIONS = ['jinja2.ext.i18n', 'jinja2.ext.autoescape', 'jinja2.ext.with_']
```

I've changed the theme's message "Tagged with" in `index.html` to experiment with plural in i18n. It is now "Tag:" if there is only one tag assigned or "Tags:" if there are more than one.