### PR TITLE
Add some blocks to page for easier customization

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -7,7 +7,9 @@
     <h1 id="{{ page.slug }}">{{ page.title }}</h1>
   </header>
   <div>
-    {{ page.content }}
+    {% block before_content %}{% endblock %}
+    {% block page_content %}{{ page.content }}{% endblock %}
+    {% block after_content %}{% endblock %}
   </div>
 </article>
 {% endblock %}


### PR DESCRIPTION
This PR adds some blocks definitions to `page.html` for easier customization.
It allows custom page templates to define `before_content` and `after_content` blocks or to override the content with `page_content` block.