### PR TITLE
New propery ADD_THIS_BELOW_ARTICLE

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -49,7 +49,11 @@
 
   {% if ADD_THIS_ID %}
   <div class="center social-share">
-    <p>{{ _('Like this article? Share it with your friends!') }}</p>
+    {% if ADD_THIS_BELOW_ARTICLE %}
+      <div class="addthis_inline_share_toolbox"></div>
+    {% else %}
+      <p>{{ _('Like this article? Share it with your friends!') }}</p>
+    {% endif %}
     <div class="addthis_native_toolbox"></div>
     <div class="addthis_sharing_toolbox"></div>
   </div>

--- a/templates/article.html
+++ b/templates/article.html
@@ -49,13 +49,8 @@
 
   {% if ADD_THIS_ID %}
   <div class="center social-share">
-    {% if ADD_THIS_BELOW_ARTICLE %}
-      <div class="addthis_inline_share_toolbox"></div>
-    {% else %}
-      <p>{{ _('Like this article? Share it with your friends!') }}</p>
-    {% endif %}
     <div class="addthis_native_toolbox"></div>
-    <div class="addthis_sharing_toolbox"></div>
+    <div class="addthis_inline_share_toolbox"></div>
   </div>
   {% endif %}
 


### PR DESCRIPTION
I prefer to have the Add This bar in-line, after my articles. This patch allows that, by adding a new property ADD_THIS_BELOW_ARTICLE. Default is no behaviour change.

Looks like this (with my Add This configuration, of couse):

![image](https://cloud.githubusercontent.com/assets/1441946/23071005/eea0c9ce-f4fa-11e6-851d-b52e1f24aab3.png)
