### PR TITLE
Fix <noscript> tag in Piwik tracking script

### DIFF
--- a/templates/partial/piwik.html
+++ b/templates/partial/piwik.html
@@ -11,5 +11,5 @@
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="//bnjbvr.alwaysdata.net/piwik/piwik.php?idsite=1" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="//{{ PIWIK_URL }}/piwik.php?idsite={{ PIWIK_SITE_ID }}" style="border:0" alt="" /></p></noscript>
 <!-- End Piwik Code -->


### PR DESCRIPTION
The Piwik tracking script has a <noscript> part. Currently, this tag makes request to an invalid URL. This PR fix the tag to respect user defined `PIWIK_URL` and `PIWIK_SITE_ID`.