### PR TITLE
Share Disqus conversations across http & https sites (and others)

### DIFF
--- a/templates/partial/disqus.html
+++ b/templates/partial/disqus.html
@@ -1,13 +1,17 @@
 {% if DISQUS_SITENAME %}
 <!-- Disqus -->
 <div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_shortname = '{{ DISQUS_SITENAME }}';
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
+<script>
+var disqus_config = function(){
+  this.page.url = '{{DISQUS_PREFIX}}' + document.location.pathname;
+};
+
+(function() { // DON'T EDIT BELOW THIS LINE
+var d = document, s = d.createElement('script');
+s.src = '//' + '{{ DISQUS_SITENAME }}' + '.disqus.com/embed.js';
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
 </script>
 <noscript>
     {{ _('Please enable JavaScript to view comments.') }}


### PR DESCRIPTION
I ran into an issue when running the site http & https -- disqus forked the discussion threads. 

I added a `DISQUS_PREFIX` = `http://mysite.com` to allow conversations to be shared across http & https.  It also helps to share the conversations during development (e.g. to test the integration & formatting).

Here is a little [more info about `disqus_config()`](https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables)

Let me know if there's a cleaner way to handle the `DISQUS_PREFIX` config
