### PR TITLE
Fix Google Tag Manager targets

### DIFF
--- a/templates/partial/gtm.html
+++ b/templates/partial/gtm.html
@@ -5,7 +5,7 @@
     w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
     var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
     j.async=true;
-    j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;
+    j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
     f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER }}');
 </script>

--- a/templates/partial/gtm_noscript.html
+++ b/templates/partial/gtm_noscript.html
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
 <noscript>
-  <iframe src="//www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  <iframe src="https://www.googletagmanager.com/ns.html?id={{ GOOGLE_TAG_MANAGER }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
The old way of pulling in the source elements (e.g. j.src='//www...') no longer works.  It now needs the protocol as well (e.g. j.src='https://www...').

I noticed this start happening on the 8th of December.  Not sure what changed, but it wasn't happening before that as far as I can tell.

I've updated the src location to include the protocol.  This has solved the issue for me.