### PR TITLE
Close the addthis relatedposts div, and only include it if addthis is enabled

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -72,8 +72,8 @@
     {% endfor %}
     </ul>
   </div>
-  {% else %}
-    <div class="addthis_relatedposts_inline">
+  {% elif ADD_THIS_ID %}
+    <div class="addthis_relatedposts_inline"></div>
   {% endif %}
 
   {% if GOOGLE_ADSENSE and GOOGLE_ADSENSE.ads.article_bottom %}


### PR DESCRIPTION
Hi,

_Because this I hope is just a really minor fix, I've just opened a PR with the fix rather than open an issue - but if you'd prefer discussion in an issue first let me know and I'll raise one._

I just took an updated version of this theme, and noted that an `addthis` `div` has appeared on all articles despite me not using that feature, and also that the `div` wasn't closed.

This small fix just closes the `div` (assuming it's supposed to be closed), and only adds it if `ADD_THIS_ID` is set, to match the block of configuration a few lines above.

Also, I built the test pages and checked this worked correctly both with and without `ADD_THIS_ID` set.

Thanks again for creating and maintaining this theme!