### PR TITLE
Striptags from neighbors article title

### DIFF
--- a/templates/partial/neighbors.html
+++ b/templates/partial/neighbors.html
@@ -1,12 +1,12 @@
 {% if 'neighbors' in PLUGINS %}
   <div class="neighbors">
   {% if article.prev_article %}
-    <a class="btn float-left" href="{{ SITEURL }}/{{ article.prev_article.url }}" title="{{ article.prev_article.title }}">
+    <a class="btn float-left" href="{{ SITEURL }}/{{ article.prev_article.url }}" title="{{ article.prev_article.title|striptags }}">
       <i class="fa fa-angle-left"></i> {{ _('Previous Post') }}
     </a>
   {% endif %}
   {% if article.next_article %}
-    <a class="btn float-right" href="{{ SITEURL }}/{{ article.next_article.url }}" title="{{ article.next_article.title }}">
+    <a class="btn float-right" href="{{ SITEURL }}/{{ article.next_article.url }}" title="{{ article.next_article.title|striptags }}">
       {{ _('Next Post') }} <i class="fa fa-angle-right"></i>
     </a>
   {% endif %}


### PR DESCRIPTION
# Overview
- Added `striptags` to `article.XXX_article.title` calls in `neighbors.html`
- HTML tags can break the button

# Example
The following example is from a post titled: `Publication in the Proceedings of the 2018 IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS 2018)`

The next/previous articles produce the following: 

![image](https://user-images.githubusercontent.com/6395915/43427779-1f6b5938-9429-11e8-9ec0-53014d4193c8.png)

```html
<a class="btn float-left" href="https://nicholasnadeau.me/publication-in-the-proceedings-of-the-2018-ieeersj-international-conference-on-intelligent-robots-and-systems-iros-2018.html" title="Publication in the Proceedings of the 2018 <span class=" caps"="">IEEE/<span class="caps">RSJ</span> International Conference on Intelligent Robots and Systems (<span class="caps">IROS</span>&nbsp;2018)"&gt;
<i class="fa fa-angle-left"></i> Previous Post
</a>
```

Notice the `<span class=" caps"` that is assigned to uppercase words? This is the cause of the bug.