### PR TITLE
Add a rel='me' for mastodon links for automatic network verification

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -123,11 +123,9 @@
 
       <ul class="social">
         {% for name, link in SOCIAL %}
-          <li><a class="sc-{{ name }}" href="{{ link }}" target="_blank">
-            <i
-              {% if name is eq 'mastodon' %}rel="me"{% endif %}
-              class="{% if name in ['envelope', 'rss'] %}fas{% else %}fab{% endif %} fa-{{ name }}"
-            >
+          <li>
+            <a {% if name is eq 'mastodon' %}rel="me"{% endif %} class="sc-{{ name }}" href="{{ link }}" target="_blank">
+            <i class="{% if name in ['envelope', 'rss'] %}fas{% else %}fab{% endif %} fa-{{ name }}">
             </i>
           </a></li>
         {% endfor %}


### PR DESCRIPTION
Since Mastodon [introduced](https://mashable.com/2017/04/06/how-to-get-verified-mastodon/?europe=true#kQCyiplSDmqL) a way to get verified on their network by providing a `<a rel="me">` link in your blog, it would be awesome to automatically support it in this theme.