### PR TITLE
add option for displaying author(s) to Posted line in index and article templates

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -19,7 +19,19 @@
     {% endif %}
     <h1 id="{{ article.slug }}">{{ article.title }}</h1>
     <p>
-      {{ _('Posted on %(when)s in %(category)s',
+      {% if not SHOW_POST_AUTHOR %}
+        {% set auth_str = '' %}
+      {% else %}
+        {% set auth_str = [] %}
+        {% for auth in article.authors %}
+          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, auth.url, auth)|safe) or ''}}
+        {% else %}
+          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, article.author.url, article.author)|safe) or ''}}
+        {% endfor %}
+        {% set auth_str = ' by ' ~ auth_str|join(', ') %}
+      {% endif %}
+      {{ _('Posted%(auth_str)s on %(when)s in %(category)s',
+           auth_str=auth_str,
            when=article.locale_date,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 

--- a/templates/article.html
+++ b/templates/article.html
@@ -25,8 +25,6 @@
         {% set auth_str = [] %}
         {% for auth in article.authors %}
           {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, auth.url, auth)|safe) or ''}}
-        {% else %}
-          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, article.author.url, article.author)|safe) or ''}}
         {% endfor %}
         {% set auth_str = ' by ' ~ auth_str|join(', ') %}
       {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,19 @@
   <header>
     <h2><a href="{{ SITEURL }}/{{ article.url }}{% if not DISABLE_URL_HASH %}#{{ article.slug }}{% endif %}">{{ article.title }}</a></h2>
     <p>
-      {{ _('Posted on %(when)s in %(category)s',
+      {% if not SHOW_POST_AUTHOR %}
+        {% set auth_str = '' %}
+      {% else %}
+        {% set auth_str = [] %}
+        {% for auth in article.authors %}
+          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, auth.url, auth)|safe) or ''}}
+        {% else %}
+          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, article.author.url, article.author)|safe) or ''}}
+        {% endfor %}
+        {% set auth_str = ' by ' ~ auth_str|join(', ') %}
+      {% endif %}
+      {{ _('Posted%(auth_str)s on %(when)s in %(category)s',
+           auth_str=auth_str,
            when=article.locale_date,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,8 +23,6 @@
         {% set auth_str = [] %}
         {% for auth in article.authors %}
           {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, auth.url, auth)|safe) or ''}}
-        {% else %}
-          {{ auth_str.append('<a href="%s/%s">%s</a>'|format(SITEURL, article.author.url, article.author)|safe) or ''}}
         {% endfor %}
         {% set auth_str = ' by ' ~ auth_str|join(', ') %}
       {% endif %}


### PR DESCRIPTION
PR for issue #84 

adds a SHOW_POST_AUTHOR setting which controls showing the authors name in the 'Posted...' line on articles and article summaries. 

If article.authors is set then it uses those, else it defaults to using article.author. 