### PR TITLE
Using PAGE_ORDER_BY as the default sorting setting.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -107,6 +107,9 @@
       {% if pages or LINKS %}
       <nav>
         <ul class="list">
+          {% if PAGE_ORDER_BY -%}
+            {% set PAGES_SORT_ATTRIBUTE = PAGE_ORDER_BY %}
+          {%- endif %}
           {% if not PAGES_SORT_ATTRIBUTE -%}
               {% set PAGES_SORT_ATTRIBUTE = 'title' %}
           {%- endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,14 +107,11 @@
       {% if pages or LINKS %}
       <nav>
         <ul class="list">
-          {% if PAGE_ORDER_BY -%}
-            {% set PAGES_SORT_ATTRIBUTE = PAGE_ORDER_BY %}
-          {%- endif %}
-          {% if not PAGES_SORT_ATTRIBUTE -%}
-              {% set PAGES_SORT_ATTRIBUTE = 'title' %}
+          {% if PAGES_SORT_ATTRIBUTE -%}
+            {% set pages = pages|sort(attribute=PAGES_SORT_ATTRIBUTE) %}
           {%- endif %}
           {% if DISPLAY_PAGES_ON_MENU %}
-          {% for page in pages|sort(attribute=PAGES_SORT_ATTRIBUTE) %}
+          {% for page in pages %}
           <li><a href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
           {% endfor %}
           {% endif %}


### PR DESCRIPTION
Added `PAGE_ORDER_BY` as the default page ordering setting. Falls back to `PAGES_SORT_ATTRIBUTE` when this is not defined.

The only instance where this can break someone's sorting behaviour is if they have both `PAGES_SORT_ATTRIBUTE` and `PAGE_ORDER_BY` defined with different values.

Related to issue #170 that I created earlier.