### PR TITLE
Support defining LINKS that open in the same window

### DIFF
--- a/docs/pelicanconf.py
+++ b/docs/pelicanconf.py
@@ -39,12 +39,6 @@ USE_FOLDER_AS_CATEGORY = False
 MAIN_MENU = True
 HOME_HIDE_TAGS = True
 
-# Valid values for LINKS_IN_NEW_TAB:
-# * Unset, None, True or any string to open all LINKS in a new window (default)
-# * 'no', 'none', False or 0 to open all LINKS in the same window
-# * 'external' to open LINKS to external sites in a new window, internal links in same window
-LINKS_IN_NEW_TAB = 'external'
-
 SOCIAL = (
     ('github', 'https://github.com/alexandrevicenzi/Flex'),
     ('rss', '/blog/feeds/all.atom.xml'),

--- a/docs/pelicanconf.py
+++ b/docs/pelicanconf.py
@@ -39,6 +39,12 @@ USE_FOLDER_AS_CATEGORY = False
 MAIN_MENU = True
 HOME_HIDE_TAGS = True
 
+# Valid values for LINKS_IN_NEW_TAB:
+# * Unset, None, True or any string to open all LINKS in a new window (default)
+# * 'no', 'none', False or 0 to open all LINKS in the same window
+# * 'external' to open LINKS to external sites in a new window, internal links in same window
+LINKS_IN_NEW_TAB = 'external'
+
 SOCIAL = (
     ('github', 'https://github.com/alexandrevicenzi/Flex'),
     ('rss', '/blog/feeds/all.atom.xml'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -110,7 +110,9 @@
           {# Open links in new window depending on the LINKS_IN_NEW_TAB setting #}
           {% macro get_target(link) -%}
             {% if LINKS_IN_NEW_TAB not in ('no', 'none', false, 0, 'external') or (LINKS_IN_NEW_TAB == "external" and not link.startswith("/") and not link.startswith(SITEURL)) %}
-            target="_blank"
+            _blank
+            {% else %}
+            _self
             {% endif %}
           {% endmacro %}
 
@@ -119,12 +121,12 @@
           {%- endif %}
           {% if DISPLAY_PAGES_ON_MENU %}
           {% for page in pages %}
-            <li><a {{ get_target(SITEURL) }} href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
+            <li><a target="{{ get_target(SITEURL) }}" href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
           {% endfor %}
           {% endif %}
 
           {% for name, link in LINKS %}
-            <li><a {{ get_target(link) }} href="{{ link }}" >{{ name }}</a></li>
+            <li><a target="{{ get_target(link) }}" href="{{ link }}" >{{ name }}</a></li>
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,18 +107,24 @@
       {% if pages or LINKS %}
       <nav>
         <ul class="list">
+          {# Open links in new window depending on the LINKS_IN_NEW_TAB setting #}
+          {% macro link_target(link) -%}
+            {% if LINKS_IN_NEW_TAB not in ('no', 'none', false, 0, 'external') or (LINKS_IN_NEW_TAB == "external" and not link.startswith("/") and not link.startswith(SITEURL)) %}
+            target="_blank"
+            {% endif %}
+          {% endmacro %}
+
           {% if PAGES_SORT_ATTRIBUTE -%}
             {% set pages = pages|sort(attribute=PAGES_SORT_ATTRIBUTE) %}
           {%- endif %}
           {% if DISPLAY_PAGES_ON_MENU %}
           {% for page in pages %}
-          <li><a href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
+            <li><a {{ link_target(SITEURL) }} href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
           {% endfor %}
           {% endif %}
 
           {% for name, link in LINKS %}
-            {# Open external links in new window, relative links in the same window #}
-            <li><a href="{{ link }}" {% if link[0] != '/' and not link.startswith(SITEURL) %}target="_blank"{% endif %}>{{ name }}</a></li>
+            <li><a {{ link_target(link) }} href="{{ link }}" >{{ name }}</a></li>
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -116,14 +116,9 @@
           {% endfor %}
           {% endif %}
 
-          {% for link_tuple in LINKS %}
-            {% if link_tuple|length == 2 %}
-            {% set name, link = link_tuple %}
-            <li><a href="{{ link }}" target="_blank">{{ name }}</a></li>
-            {% else %}
-            {% set name, link, new_window = link_tuple %}
-            <li><a href="{{ link }}" {% if new_window %}target="_blank"{% endif %}>{{ name }}</a></li>
-            {% endif %}
+          {% for name, link in LINKS %}
+            {# Open external links in new window, relative links in the same window #}
+            <li><a href="{{ link }}" {% if link[:4] == 'http' %}target="_blank"{% endif %}>{{ name }}</a></li>
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -108,7 +108,7 @@
       <nav>
         <ul class="list">
           {# Open links in new window depending on the LINKS_IN_NEW_TAB setting #}
-          {% macro link_target(link) -%}
+          {% macro get_target(link) -%}
             {% if LINKS_IN_NEW_TAB not in ('no', 'none', false, 0, 'external') or (LINKS_IN_NEW_TAB == "external" and not link.startswith("/") and not link.startswith(SITEURL)) %}
             target="_blank"
             {% endif %}
@@ -119,12 +119,12 @@
           {%- endif %}
           {% if DISPLAY_PAGES_ON_MENU %}
           {% for page in pages %}
-            <li><a {{ link_target(SITEURL) }} href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
+            <li><a {{ get_target(SITEURL) }} href="{{ SITEURL }}/{{ page.url }}{% if not DISABLE_URL_HASH %}#{{ page.slug }}{% endif %}">{{ page.title }}</a></li>
           {% endfor %}
           {% endif %}
 
           {% for name, link in LINKS %}
-            <li><a {{ link_target(link) }} href="{{ link }}" >{{ name }}</a></li>
+            <li><a {{ get_target(link) }} href="{{ link }}" >{{ name }}</a></li>
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -118,7 +118,7 @@
 
           {% for name, link in LINKS %}
             {# Open external links in new window, relative links in the same window #}
-            <li><a href="{{ link }}" {% if link[:4] == 'http' %}target="_blank"{% endif %}>{{ name }}</a></li>
+            <li><a href="{{ link }}" {% if link[0] != '/' and not link.startswith(SITEURL) %}target="_blank"{% endif %}>{{ name }}</a></li>
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -116,8 +116,14 @@
           {% endfor %}
           {% endif %}
 
-          {% for name, link in LINKS %}
-          <li><a href="{{ link }}" target="_blank">{{ name }}</a></li>
+          {% for link_tuple in LINKS %}
+            {% if link_tuple|length == 2 %}
+            {% set name, link = link_tuple %}
+            <li><a href="{{ link }}" target="_blank">{{ name }}</a></li>
+            {% else %}
+            {% set name, link, new_window = link_tuple %}
+            <li><a href="{{ link }}" {% if new_window %}target="_blank"{% endif %}>{{ name }}</a></li>
+            {% endif %}
           {% endfor %}
         </ul>
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -109,12 +109,16 @@
         <ul class="list">
           {# Open links in new window depending on the LINKS_IN_NEW_TAB setting #}
           {% macro get_target(link) -%}
-            {% if LINKS_IN_NEW_TAB not in ('no', 'none', false, 0, 'external') or (LINKS_IN_NEW_TAB == "external" and not link.startswith("/") and not link.startswith(SITEURL)) %}
+            {%- if LINKS_IN_NEW_TAB is not defined -%}
             _blank
-            {% else %}
+            {%- elif LINKS_IN_NEW_TAB in ('all', none, true) -%}
+            _blank
+            {%- elif LINKS_IN_NEW_TAB == "external" and not link.startswith("/") and not link.startswith(SITEURL) -%}
+            _blank
+            {%- else -%}
             _self
-            {% endif %}
-          {% endmacro %}
+            {%- endif -%}
+          {%- endmacro %}
 
           {% if PAGES_SORT_ATTRIBUTE -%}
             {% set pages = pages|sort(attribute=PAGES_SORT_ATTRIBUTE) %}


### PR DESCRIPTION
Currently all `LINKS` open in a new window (`target="_blank"`), but in some cases it's desirable to open them in the same window. For example I use it for linking to categories and tags:

```
LINKS = (
    ('Categories', SITEURL+'/categories#categories', False),
    ('Tags', SITEURL+'/tags#tags', False),
)
```

Old format and experience is still supported, this is backwards-compatible.