### PR TITLE
Set alternate link tags for translated content

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -5,6 +5,13 @@
 <meta name="description" content="{{ article.summary|striptags|escape }}" />
 <meta name="keywords" content="{{ article.tags|join(', ')|escape }}">
 
+{% if article.translations -%}
+<link rel="alternate" href="{{ SITEURL }}/{{ article.url }}" hreflang="{{ article.lang }}" />
+{% for a in article.translations %}
+<link rel="alternate" href="{{ SITEURL }}/{{ a.url }}" hreflang="{{ a.lang }}" />
+{% endfor %}
+{% endif %}
+
 {% include "partial/og_article.html" %}
 {% endblock %}
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,16 @@
 {% extends "base.html" %}
 
+{% block meta %}
+{{ super() }}
+
+{% if page.translations -%}
+<link rel="alternate" href="{{ SITEURL }}/{{ page.url }}" hreflang="{{ page.lang }}" />
+{% for p in page.translations %}
+<link rel="alternate" href="{{ SITEURL }}/{{ p.url }}" hreflang="{{ p.lang }}" />
+{% endfor %}
+{% endif %}
+{% endblock %}
+
 {% block title %} &ndash; {{ page.title }}{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
`<link rel="alternate">` is good practice for SEO and helps people find the content in their preferred language.