### PR TITLE
Fix: Custom css for multi languages site

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/font-awesome/css/solid.css">
 
   {% if CUSTOM_CSS %}
-    <link href="{{ SITEURL }}/{{ CUSTOM_CSS }}" rel="stylesheet">
+    <link href="{{ main_siteurl }}/{{ CUSTOM_CSS }}" rel="stylesheet">
   {% endif %}
 
   {% if FEED_ALL_ATOM %}


### PR DESCRIPTION
Hi,
Like I said in my previous PR #191 I have written my own css file.
The `CUSTOM_CSS` variable, do not work well, when the site is multi-language because the value of `SITEURL` depend of the language used by user.
To fix the problem I use `main_siteurl` to have the same URL to all languages.
Best regards,
Loïc Penaud