### PR TITLE
Upgrade gulp to latest version (v4)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,4 +28,4 @@ gulp.task('pygments', function () {
 });
 
 
-gulp.task('default', ['less', 'cp', 'pygments']);
+gulp.task('default', gulp.series(['less', 'cp', 'pygments']));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/alexandrevicenzi/Flex#readme",
   "dependencies": {
     "font-awesome": "^4.6.1",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.1",
     "gulp-cssnano": "^2.1.3",
     "gulp-less": "^3.5.0",
     "gulp-rename": "^1.3.0"


### PR DESCRIPTION
Closes #198 

* Upgrades `gulp` in the `package.json` file to the latest version.
* Migrate `gulpfile.js` to new task syntax. (Used https://www.sitepoint.com/how-to-migrate-to-gulp-4/ as a reference.)