### PR TITLE
Auto-detect Tipue Search plugin

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,7 @@
           href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/pygments/{{ PYGMENTS_STYLE|default('github') }}.min.css">
   {% endif %}
 
-  {% if USE_TIPUE_SEARCH %}
+  {% if 'tipue_search' in PLUGINS %}
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/jquery.min.js"></script>
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/tipuesearch.min.js"></script>
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/tipuesearch.min.js"></script>
@@ -156,7 +156,7 @@
       <h1><a href="{{ SITEURL }}">{{ SITETITLE }}</a></h1>
 
       {% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}
-      {% if USE_TIPUE_SEARCH %}
+      {% if 'tipue_search' in PLUGINS %}
         <form class="navbar-search" action="/search.html" role="search">
             <input type="text" name="q" id="tipue_search_input" placeholder="Search..">
         </form>
@@ -276,7 +276,7 @@
   {% include 'partial/github.html' %}
   {% endif %}
 
-  {% if USE_TIPUE_SEARCH %}
+  {% if 'tipue_search' in PLUGINS %}
     <script>
       $(document).ready(function() {
           $('#tipue_search_input').tipuesearch();

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-{% if USE_TIPUE_SEARCH %} {% extends 'base.html' %} {% block title %} {{ _('Search') }} - {{ SITENAME|striptags }} {% endblock title %} {% block content %}
+{% if 'tipue_search' in PLUGINS %} {% extends 'base.html' %} {% block title %} {{ _('Search') }} - {{ SITENAME|striptags }} {% endblock title %} {% block content %}
 <script>
     $(document).ready(function() {
         $('#tipue_search_input').tipuesearch({


### PR DESCRIPTION
The existing Tipue Search integration doesn't automatically detect Tipue Search if it's enabled in `PLUGINS`. This PR changes that so it is more consistent with the other plugin integrations.