### PR TITLE
Fixing missing </div> caught by validator.w3.org

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -220,6 +220,7 @@
         (adsbygoogle = window.adsbygoogle || []).push({});
       </script>
     {% endif %}
+    </div>
   </aside>
   <main>
     {% if GOOGLE_ADSENSE and GOOGLE_ADSENSE.ads.main_menu %}


### PR DESCRIPTION
The errors given were:
Error: End tag aside seen, but there were open elements.
Error: Unclosed element div.

They were caused by a missing </div> just inside an <aside> block.