### PR TITLE
Fixing illegal character caught by validator.w3.org

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% if USE_GOOGLE_FONTS != False %}
-  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro%7CSource+Sans+Pro:300,400,400i,700" rel="stylesheet">
   {% endif %}
 
   {% if USE_LESS %}


### PR DESCRIPTION
The error shown was:
Error: Illegal character in query: | is not allowed.

Even though Google says here:

  https://developers.google.com/fonts/docs/getting_started

that multiple font families should be separated by pipe character,
they state here:

  https://developers.google.com/maps/documentation/urls/url-encoding

that a pipe character should be encoded as %7C which agrees with
https://www.ietf.org/rfc/rfc3986.txt.