### PR TITLE
Update Google fonts to remove unused weight and CSS API v2.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,7 +18,7 @@
   {% endif %}
 
   {% if USE_GOOGLE_FONTS != False %}
-  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,700;1,400&family=Source+Sans+Pro:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
   {% endif %}
 
   {% if USE_LESS %}


### PR DESCRIPTION
The 300 weight of Source Code Pro is not used anywhere.  This change
also updates to using Google Fonts CSS API v2 and specifying
display=swap to avoid a "flash of invisible text".

Resolves #241