### PR TITLE
Place copyright year ahead of copyright name

### DIFF
--- a/templates/partial/cc_license.html
+++ b/templates/partial/cc_license.html
@@ -1,5 +1,5 @@
 <p>
-  &copy; {{ COPYRIGHT_NAME }} {{ COPYRIGHT_YEAR }} - This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/{{ CC_LICENSE['slug'] }}/{{ CC_LICENSE['version'] }}/">{{ CC_LICENSE['name'] }} {{ CC_LICENSE['version'] }} International License</a>
+  &copy; {{ COPYRIGHT_YEAR }} {{ COPYRIGHT_NAME }} - This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/{{ CC_LICENSE['slug'] }}/{{ CC_LICENSE['version'] }}/">{{ CC_LICENSE['name'] }} {{ CC_LICENSE['version'] }} International License</a>
 </p>
 {% include "partial/flex.html" %}
 <p>

--- a/templates/partial/copyright.html
+++ b/templates/partial/copyright.html
@@ -1,4 +1,4 @@
-<p>&copy; {{ COPYRIGHT_NAME }} {{ COPYRIGHT_YEAR }}</p>
+<p>&copy; {{ COPYRIGHT_YEAR }} {{ COPYRIGHT_NAME }}</p>
 {% include "partial/flex.html" %}
 {% if STATUSCAKE %}
   {% include "partial/statuscake.html" %}


### PR DESCRIPTION
Traditional placement is to have the year precede the name, so
modifying standard templates to match this.

Fixes alexandrevicenzi/Flex#244.