### PR TITLE
Fix compatibility with Pelican 4.5.0 when PLUGINS is not set

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -30,7 +30,7 @@
            when=article.locale_date,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 
-      {% if 'post_stats' in PLUGINS %}
+      {% if PLUGINS and 'post_stats' in PLUGINS %}
         &#8226; {{ _('%(minutes)s min read', minutes=article.stats['read_mins']) }}
       {% endif %}
     </p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,7 @@
           href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/pygments/{{ PYGMENTS_STYLE|default('github') }}.min.css">
   {% endif %}
 
-  {% if 'tipue_search' in PLUGINS %}
+  {% if PLUGINS and 'tipue_search' in PLUGINS %}
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/jquery.min.js"></script>
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/tipuesearch.min.js"></script>
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/tipuesearch/tipuesearch.min.js"></script>
@@ -156,7 +156,7 @@
 
       {% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}
 
-      {% if 'tipue_search' in PLUGINS %}
+      {% if PLUGINS and 'tipue_search' in PLUGINS %}
         <form class="navbar-search" action="/search.html" role="search">
           <input type="text" name="q" id="tipue_search_input" placeholder="{{ _('Search...') }}">
         </form>
@@ -280,7 +280,7 @@
     {% include 'partial/github.html' %}
   {% endif %}
 
-  {% if 'tipue_search' in PLUGINS %}
+  {% if PLUGINS and 'tipue_search' in PLUGINS %}
     <script>
       $(document).ready(function() {
         $('#tipue_search_input').tipuesearch();

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
           {% endfor %}
       {% endif %}
 
-      {% if 'post_stats' in PLUGINS %}
+      {% if PLUGINS and 'post_stats' in PLUGINS %}
         &#8226; {{ _('%(minutes)s min read', minutes=article.stats['read_mins']) }}
       {% endif %}
     </p>

--- a/templates/partial/neighbors.html
+++ b/templates/partial/neighbors.html
@@ -1,4 +1,4 @@
-{% if 'neighbors' in PLUGINS %}
+{% if PLUGINS and 'neighbors' in PLUGINS %}
   <div class="neighbors">
   {% if article.prev_article %}
     <a class="btn float-left" href="{{ SITEURL }}/{{ article.prev_article.url }}" title="{{ article.prev_article.title|striptags }}">

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-{% if 'tipue_search' in PLUGINS %}
+{% if PLUGINS and 'tipue_search' in PLUGINS %}
 {% extends 'base.html' %}
 {% block title %}{{ _('Search') }} - {{ SITENAME|striptags }}{% endblock title %}
 {% block content %}


### PR DESCRIPTION
Pelican 4.5.0 changed the plugins mechanism and the default for
PLUGINS is now None.  The following type of construct is used in a
number of places in Flex:

    {% if 'tipue_search' in PLUGINS %}

If PLUGINS is not set in pelicanconf.py, the following exception will
be triggered under Pelican 4.5.0:

    TypeError: argument of type 'NoneType' is not iterable

The Pelican maintainers did not intend the examination of PLUGINS by
templates to be a stable API (per a discussion on IRC).  Per their
request, an enhancement request for a mechanism to do this has been
submitted here: https://github.com/getpelican/pelican/issues/2797

This commit changes the problematic constructs in Flex to be in the
style of:

    {% if PLUGINS and 'tipue_search' in PLUGINS %}

This allows Flex to work with Pelican 4.5.0 even if users do not
define PLUGINS.  Note that to use the new namespace plugins in Pelican
4.5.0, PLUGINS will have to be left at its default of None.

Resolves #245