### PR TITLE
Add Google Global Site Tags configuration for Google Analytics 4

### DIFF
--- a/docs/pelicanconf.py
+++ b/docs/pelicanconf.py
@@ -77,3 +77,7 @@ THEME_COLOR_AUTO_DETECT_BROWSER_PREFERENCE = True
 THEME_COLOR_ENABLE_USER_OVERRIDE = True
 
 USE_LESS = True
+
+# GOOGLE ANALYTICS
+# For Google Analytics 4 use. Note that for old Google Analytics ('UA-XXXXX') the GOOGLE_ANALYTICS variable is included in publishconfig.py
+# GOOGLE_GLOBAL_SITE_TAG = 'G-XXXXX'

--- a/templates/base.html
+++ b/templates/base.html
@@ -102,6 +102,10 @@
   {% if GOOGLE_ANALYTICS %}
     {% include "partial/ga.html" %}
   {% endif %}
+  
+  {% if GOOGLE_GLOBAL_SITE_TAG %}
+    {% include "partial/ggst.html" %}
+  {% endif %}
 
   {% if BROWSER_COLOR %}
     <!-- Chrome, Firefox OS and Opera -->

--- a/templates/partial/ggst.html
+++ b/templates/partial/ggst.html
@@ -1,0 +1,10 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_GLOBAL_SITE_TAG }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ GOOGLE_GLOBAL_SITE_TAG }}');
+</script>
+<!-- End of Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
… This addition enables users to set their Google Measurement ID into the variable GOOGLE_GLOBAL_SITE_TAG in pelicanconf so that they can track analytics using GA 4 Closes #256