### PR TITLE
Add support for SEO Pelican plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The minimalist [Pelican](http://blog.getpelican.com/) theme.
 - [Representative image](https://github.com/getpelican/pelican-plugins/tree/master/representative_image)
 - [Neighbors](https://github.com/getpelican/pelican-plugins/tree/master/neighbors)
 - [Tipue Search](https://github.com/getpelican/pelican-plugins/blob/master/tipue_search/)
+- [SEO](https://github.com/pelican-plugins/seo)
 
 ## Install
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -114,19 +114,22 @@
     <meta name="msapplication-TileColor" content="{{ BROWSER_COLOR }}">
   {% endif %}
 
-  {% if REL_CANONICAL %}
-    {% if page %}
-      <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}">
-    {% elif article %}
-      <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}">
-    {% elif page_name == 'index' and not articles_previous_page %}
-      <link rel="canonical" href="{{ SITEURL }}">
-    {% elif author or category or tag or page_name == 'index' %}
-      <link rel="canonical" href="{{ SITEURL }}/{{ articles_page.url }}">
-    {% else %}
-      <link rel="canonical" href="{{ SITEURL }}/{{ output_file }}">
+  {% if not PLUGINS or 'seo' not in PLUGINS %}
+    {% if REL_CANONICAL %}
+      {% if page %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ page.url }}">
+      {% elif article %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ article.url }}">
+      {% elif page_name == 'index' and not articles_previous_page %}
+        <link rel="canonical" href="{{ SITEURL }}">
+      {% elif author or category or tag or page_name == 'index' %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ articles_page.url }}">
+      {% else %}
+        <link rel="canonical" href="{{ SITEURL }}/{{ output_file }}">
+      {% endif %}
     {% endif %}
-  {% endif %}
+  {% endif %} 
+
   {% block meta %}
     <meta name="author" content="{{ AUTHOR }}" />
     <meta name="description" content="{{ SITEDESCRIPTION }}" />

--- a/templates/partial/jsonld_article.html
+++ b/templates/partial/jsonld_article.html
@@ -1,23 +1,25 @@
-{% if SITELOGO %}
-  {% set default_cover = SITELOGO %}
-{% else %}
-  {% set default_cover = '{{ SITEURL }}/{{ THEME_STATIC_DIR }}/img/profile.png' %}
+{% if not PLUGINS or 'seo' not in PLUGINS %}
+  {% if SITELOGO %}
+    {% set default_cover = SITELOGO %}
+  {% else %}
+    {% set default_cover = '{{ SITEURL }}/{{ THEME_STATIC_DIR }}/img/profile.png' %}
+  {% endif %}
+  <script type="application/ld+json">
+  {
+    "@context": "http://schema.org",
+    "@type": "BlogPosting",
+    "name": "{{ article.title|striptags }}",
+    "headline": "{{ article.title|striptags }}",
+    "datePublished": "{{ article.date }}",
+    "dateModified": "{{ article.modified }}",
+    "author": {
+      "@type": "Person",
+      "name": "{{ article.author.name }}",
+      "url": "{{ SITEURL }}/{{ article.author.url }}"
+    },
+    "image": "{{ article.metadata.get('cover', default_cover) }}",
+    "url": "{{ SITEURL }}/{{ article.url }}",
+    "description": "{{ article.summary|striptags }}"
+  }
+  </script>
 {% endif %}
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "BlogPosting",
-  "name": "{{ article.title|striptags }}",
-  "headline": "{{ article.title|striptags }}",
-  "datePublished": "{{ article.date }}",
-  "dateModified": "{{ article.modified }}",
-  "author": {
-    "@type": "Person",
-    "name": "{{ article.author.name }}",
-    "url": "{{ SITEURL }}/{{ article.author.url }}"
-  },
-  "image": "{{ article.metadata.get('cover', default_cover) }}",
-  "url": "{{ SITEURL }}/{{ article.url }}",
-  "description": "{{ article.summary|striptags }}"
-}
-</script>

--- a/templates/partial/og.html
+++ b/templates/partial/og.html
@@ -1,14 +1,16 @@
-{% if OG_LOCALE %}
-  {% set default_locale = OG_LOCALE %}
-{% else %}
-  {% set default_locale = 'en_US' %}
-{% endif %}
-<meta property="og:site_name" content="{{ SITENAME }}"/>
-<meta property="og:type" content="blog"/>
-<meta property="og:title" content="{{ SITENAME }}"/>
-<meta property="og:description" content="{{ SITEDESCRIPTION }}"/>
-<meta property="og:locale" content="{{ default_locale }}"/>
-<meta property="og:url" content="{{ SITEURL }}"/>
-{% if SITELOGO %}
-<meta property="og:image" content="{{ SITELOGO }}">
+{% if not PLUGINS or 'seo' not in PLUGINS %}
+  {% if OG_LOCALE %}
+    {% set default_locale = OG_LOCALE %}
+  {% else %}
+    {% set default_locale = 'en_US' %}
+  {% endif %}
+  <meta property="og:site_name" content="{{ SITENAME }}"/>
+  <meta property="og:type" content="blog"/>
+  <meta property="og:title" content="{{ SITENAME }}"/>
+  <meta property="og:description" content="{{ SITEDESCRIPTION }}"/>
+  <meta property="og:locale" content="{{ default_locale }}"/>
+  <meta property="og:url" content="{{ SITEURL }}"/>
+  {% if SITELOGO %}
+  <meta property="og:image" content="{{ SITELOGO }}">
+  {% endif %}
 {% endif %}

--- a/templates/partial/og_article.html
+++ b/templates/partial/og_article.html
@@ -1,23 +1,25 @@
-{% if OG_LOCALE %}
-  {% set default_locale = OG_LOCALE %}
-{% else %}
-  {% set default_locale = 'en_US' %}
-{% endif %}
-<meta property="og:site_name" content="{{ SITENAME }}"/>
-<meta property="og:title" content="{{ article.title|striptags|escape }}"/>
-<meta property="og:description" content="{{ article.summary|striptags|escape }}"/>
-<meta property="og:locale" content="{{ article.metadata.get('og_locale', default_locale) }}"/>
-<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>
-<meta property="og:type" content="article"/>
-<meta property="article:published_time" content="{{ article.date }}"/>
-<meta property="article:modified_time" content="{{ article.modified }}"/>
-<meta property="article:author" content="{{ SITEURL }}/{{ article.author.url }}">
-<meta property="article:section" content="{{ article.category.name }}"/>
-{% for tag in article.tags %}
-<meta property="article:tag" content="{{ tag.name|escape }}"/>
-{% endfor %}
-{% if 'cover' in article.metadata %}
-<meta property="og:image" content="{{ SITEURL }}/{{ article.metadata['cover'] }}">
-{% else %}
-<meta property="og:image" content="{{ SITELOGO }}">
+{% if not PLUGINS or 'seo' not in PLUGINS %}
+  {% if OG_LOCALE %}
+    {% set default_locale = OG_LOCALE %}
+  {% else %}
+    {% set default_locale = 'en_US' %}
+  {% endif %}
+  <meta property="og:site_name" content="{{ SITENAME }}"/>
+  <meta property="og:title" content="{{ article.title|striptags|escape }}"/>
+  <meta property="og:description" content="{{ article.summary|striptags|escape }}"/>
+  <meta property="og:locale" content="{{ article.metadata.get('og_locale', default_locale) }}"/>
+  <meta property="og:url" content="{{ SITEURL }}/{{ article.url }}"/>
+  <meta property="og:type" content="article"/>
+  <meta property="article:published_time" content="{{ article.date }}"/>
+  <meta property="article:modified_time" content="{{ article.modified }}"/>
+  <meta property="article:author" content="{{ SITEURL }}/{{ article.author.url }}">
+  <meta property="article:section" content="{{ article.category.name }}"/>
+  {% for tag in article.tags %}
+  <meta property="article:tag" content="{{ tag.name|escape }}"/>
+  {% endfor %}
+  {% if 'cover' in article.metadata %}
+  <meta property="og:image" content="{{ SITEURL }}/{{ article.metadata['cover'] }}">
+  {% else %}
+  <meta property="og:image" content="{{ SITELOGO }}">
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
#254 

Targets: Open Graph, JSONLD, URL canonical.
I did not add the condition for `jsonld.html` as the SEO plugin doesn't support yet this case.