### PR TITLE
Support the Series plugin

### DIFF
--- a/.github/workflows/pelican-test.yaml
+++ b/.github/workflows/pelican-test.yaml
@@ -1,0 +1,28 @@
+name: Pelican test
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The minimalist [Pelican](http://blog.getpelican.com/) theme.
 - Open Graph
 - Rich Snippets (JSON-LD)
 - Related Posts (via [plugin](https://github.com/getpelican/pelican-plugins/tree/master/related_posts) or AddThis)
+- Series (via [plugin](https://github.com/pelican-plugins/series))
 - Minute read (via [plugin](https://github.com/getpelican/pelican-plugins/tree/master/post_stats))
 - [Multiple Code Highlight Styles](https://github.com/alexandrevicenzi/Flex/wiki/Code-Highlight)
 - [Translation Support](https://github.com/alexandrevicenzi/Flex/wiki/Translations)
@@ -41,6 +42,7 @@ The minimalist [Pelican](http://blog.getpelican.com/) theme.
 - [I18N Sub-sites](https://github.com/getpelican/pelican-plugins/tree/master/i18n_subsites)
 - [Minute read](https://github.com/getpelican/pelican-plugins/tree/master/post_stats)
 - [Related Posts](https://github.com/getpelican/pelican-plugins/tree/master/related_posts)
+- [Series](https://github.com/pelican-plugins/series)
 - [Representative image](https://github.com/getpelican/pelican-plugins/tree/master/representative_image)
 - [Neighbors](https://github.com/getpelican/pelican-plugins/tree/master/neighbors)
 - [Tipue Search](https://github.com/getpelican/pelican-plugins/blob/master/tipue_search/)

--- a/templates/article.html
+++ b/templates/article.html
@@ -83,6 +83,29 @@
     <div class="addthis_relatedposts_inline"></div>
   {% endif %}
 
+  {% if article.series %}
+  <div class="related-posts">
+   {% set text = SERIES_TEXT|default('Part %(index)s of the %(name)s series') %}
+    <h4>{{ text|format(index=article.series.index, name=article.series.name) }}</h4>
+    {% if article.series.all_previous %}
+       <h5>Previous articles</h5>
+       <ul>
+       {% for article in article.series.all_previous %}
+           <li><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></li>
+       {% endfor %}
+       </ul>
+    {% endif %}
+    {% if article.series.all_next %}
+       <h5>Next articles</h5>
+       <ul>
+       {% for article in article.series.all_next %}
+           <li><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></li>
+       {% endfor %}
+       </ul>
+    {% endif %}
+  </div>
+  {% endif %}
+
   {% if GOOGLE_ADSENSE and GOOGLE_ADSENSE.ads.article_bottom %}
     <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
     <ins class="adsbygoogle ads-responsive"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py{36,37,38,39}
+skipsdist = True
+
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    
+[testenv]
+deps =
+  -r docs/requirements.txt
+commands =
+  pelican -s docs/pelicanconf.py


### PR DESCRIPTION
Add support for the [Series](https://github.com/pelican-plugins/series) plugin (see discussion in #289), and update the README to that effect.

Also, to ensure that neither this addition nor any future addition introduces obvious breakage into the theme, add a tiny test facility using `tox` and a GitHub Actions workflow that test-builds the docs site.

(Side note, it looks like this project no longer uses Travis, so another patch might want to remove the `.travis.yml` configuration file.)