### PR TITLE
Fix: correct custom CSS URL for I18N pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -78,7 +78,7 @@
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/font-awesome/css/solid.css">
 
   {% if CUSTOM_CSS %}
-    <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ CUSTOM_CSS }}">
+  <link rel="stylesheet" type="text/css" href="{% if main_siteurl is defined %}{{ main_site }}{% else %}{{ SITEURL }}{% endif %}/{{ CUSTOM_CSS }}">
   {% endif %}
 
   {% if FEED_ALL_ATOM %}


### PR DESCRIPTION
## problem description:

When using the i18n_subsites plugin – which is somehow supported by this
theme – the SITEURL is modified for all but the default language,
causing the construction {{ SITEURL }}/{{ CUSTOM_CSS }} to change as
well.
This in principle affects all such template constructions where SITEURL
is prepended to a custom loading path.
One exception is {{ THEME_STATIC_DIR }}, which is adjusted by the
i18n_subsites code to still match for translations.

## solution:

The i18n plugin introduces an additional context variable
{{ main_siteurl }}, which always points at the original unmodified
SITEURL. As unfortunately this variable is not present in non-i18n
sites, it's existence is checked first, taking SITEURL as a fallback.
This special handling is acceptable IMHO, as at first glance I could not
find any other affected URLs in templates.

follow-up to #192