### PR TITLE
page template: strip tags from site title

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -11,7 +11,7 @@
 {% endif %}
 {% endblock %}
 
-{% block title %} &ndash; {{ page.title }}{% endblock %}
+{% block title %} &ndash; {{ page.title|striptags|escape }}{% endblock %}
 
 {% block content %}
 <article class="single">


### PR DESCRIPTION
A website's `<title>` cannot contain further html formatting and
layouting elements. Thus, as already done in the article template,
additional html tags need to be stripped from the title to not appear in
verbatim in a browser's title page.

This is relevant when using TYPOGRIFY integration, as that might also
augment a page title with further html elements automatically.