### PR TITLE
Add support for Plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The minimalist [Pelican](http://blog.getpelican.com/) theme.
 - [Google Analytics](https://www.google.com/analytics/web/)
 - [Google Tag Manager](https://www.google.com/tagmanager/)
 - [Matomo Analytics (formerly Piwik)](https://matomo.org/)
+- [Plausible](https://plausible.io/)
 - [StatusCake](https://www.statuscake.com/)
 - [Isso](https://posativ.org/isso/)
 - [Microsoft Clarity](https://clarity.microsoft.com)

--- a/templates/base.html
+++ b/templates/base.html
@@ -100,6 +100,8 @@
   {% include "partial/ga.html" %}
   {% include "partial/ggst.html" %}
 
+  {% include "partial/plausible.html" %}
+
   {% if not PLUGINS or 'seo' not in PLUGINS %}
     {% if REL_CANONICAL %}
       {% if page %}

--- a/templates/partial/plausible.html
+++ b/templates/partial/plausible.html
@@ -1,0 +1,3 @@
+{% if PLAUSIBLE_DOMAIN %}
+<script defer data-domain="{{ PLAUSIBLE_DOMAIN }}" src="https://plausible.io/js/plausible.js"></script>
+{% endif %}


### PR DESCRIPTION
Introduce a new configuration option, `PLAUSIBLE_DOMAIN`. If set, include the Plausible (https://plausible.io) analytics script for that domain.

Fixes #317.