### PR TITLE
Add support for Cloudflare Web Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The minimalist [Pelican](http://blog.getpelican.com/) theme.
 - [Google Analytics](https://www.google.com/analytics/web/)
 - [Google Tag Manager](https://www.google.com/tagmanager/)
 - [Matomo Analytics (formerly Piwik)](https://matomo.org/)
+- [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/)
 - [Plausible](https://plausible.io/)
 - [StatusCake](https://www.statuscake.com/)
 - [Isso](https://posativ.org/isso/)

--- a/templates/base.html
+++ b/templates/base.html
@@ -182,6 +182,7 @@
   {% include "partial/matomo.html" %}
   {% include 'partial/github.html' %}
   {% include 'partial/stork.html' %}
+  {% include 'partial/cf_analytics.html' %}
 
   {% block additional_js %}{% endblock %}
 </body>

--- a/templates/partial/cf_analytics.html
+++ b/templates/partial/cf_analytics.html
@@ -1,0 +1,6 @@
+{% if CLOUDFLARE_WEB_ANALYTICS_TOKEN %}
+<script defer
+  src='https://static.cloudflareinsights.com/beacon.min.js'
+  data-cf-beacon='{"token": "{{ CLOUDFLARE_WEB_ANALYTICS_TOKEN }}"}'>
+</script>
+{% endif %}


### PR DESCRIPTION
Hello! This PR adds support for Cloudflare web analytics once `CLOUDFLARE_WEB_ANALYTICS_TOKEN` is populated with a token that can be found in your Cloudflare dashboard when setting up web analytics. I figured this was straightforward enough to change without opening an issue for it or discussing it prior, but let me know if you'd like me to create an issue first and I can do that. Thank you!