### PR TITLE
Update the statistics extension integration used to show reading time if present

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -30,7 +30,7 @@
            when=article.locale_date,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 
-      {% if PLUGINS and 'post_stats' in PLUGINS %}
+      {% if PLUGINS and 'pelican.plugins.statistics' in PLUGINS and article.stats %}
         &#8226; {{ _('%(minutes)s min read', minutes=article.stats['read_mins']) }}
       {% endif %}
     </p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
           {% endfor %}
       {% endif %}
 
-      {% if PLUGINS and 'post_stats' in PLUGINS %}
+      {% if PLUGINS and 'pelican.plugins.statistics' in PLUGINS %}
         &#8226; {{ _('%(minutes)s min read', minutes=article.stats['read_mins']) }}
       {% endif %}
     </p>


### PR DESCRIPTION
The extension changed name and also for some reason sometimes the extension don't add the *stats* attribute to the article object, so I'm checking for that on the article template.